### PR TITLE
fix: Update header imports for fmtv12.2.0

### DIFF
--- a/src/menu_highlight.cpp
+++ b/src/menu_highlight.cpp
@@ -1,6 +1,11 @@
 #include <string>
 #include <cmath>
+#include <fmt/base.h>
+#if FMT_VERSION >= 120200
+#include <fmt/format.h>
+#else
 #include <fmt/core.h>
+#endif
 
 #include "image.hpp"
 #include "layout.hpp"

--- a/src/sidebar_highlight.cpp
+++ b/src/sidebar_highlight.cpp
@@ -1,6 +1,11 @@
 #include <string>
 #include <cmath>
+#include <fmt/base.h>
+#if FMT_VERSION >= 120200
+#include <fmt/format.h>
+#else
 #include <fmt/core.h>
+#endif
 
 #include "sidebar_highlight.hpp"
 #include "config.hpp"


### PR DESCRIPTION
In fmt version 12.2.0, <fmt/core.h> was made equivalent to <fmt/base.h>, so code relying on <fmt/format.h>
needs to direct import it now. See the [fmt changelog](https://github.com/fmtlib/fmt/blob/588b3a0f8f6a8bcf2a959cae882d5b2703e86737/ChangeLog.md?plain=1#L113-L116)